### PR TITLE
Add https capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,6 @@ Result:
 ## Requirements
 - KOReader 2024.x or newer (tested with: 2025.10 "Ghost" on a Kindle Basic 2024)  
 - Home Assistant instance with a Long-Lived Access Token
-- HTTP access to Home Assistant (HTTPS currently not supported - use on local network)
 
 ## Screenshots
 

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,8 @@
 return {
     -- Home Assistant connection settings
-    host = "192.168.1.10", -- Change to your Home Assistant IP Address
-    port = 8123,           -- Default Home Assistant Port
+    host = "192.168.1.10", -- Change to your Home Assistant IP Address or Hostname
+    https = false,         -- False or empty for http, true for https
+    port = 8123,           -- Default Home Assistant Port (probably 443 if using https)
     token =                -- Change to your own Long-Lived Access Token
     "PasteYourHomeAssistantLong-LivedAccessTokenHere",
 

--- a/main.lua
+++ b/main.lua
@@ -147,7 +147,7 @@ end
 -- Flow: build URL & body -> performRequest -> display result message to user
 function HomeAssistant:onActivateHAEvent(entity)
     local url, method, service_data
-    local base_url = string.format("http://%s:%d", ha_config.host, ha_config.port)
+    local base_url = string.format("%s://%s:%d", ha_config.https and "https" or "http", ha_config.host, ha_config.port)
 
     if entity.template then
         url = string.format("%s/api/template", base_url)


### PR DESCRIPTION
I didn't want to send a Home Assistant token in plaintext over HTTP, even on my local network. This patch adds an `https` parameter to the config. If  true, requests to Home Assistant are done over HTTPS rather than HTTP.

Even though a new parameter is added in config, this is a non breaking change with old configs. If the `https`  parameter is missing it will be treated as false.