### PR TITLE
Feature: support interactive input actions

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -163,4 +163,16 @@ function API:statesAsTemplate(entity)
     return self:performRequest(entity, url, "POST", service_data)
 end
 
+--- GET /api/states/<entity_id> - Fetch a single attribute value from an entity's state
+-- Returns (attribute_value, entity_state_string) on success, or (nil, nil) on failure
+function API:getAttributeValue(entity_id, attribute_name)
+    local url = string.format("%s/api/states/%s", self.base_url, entity_id)
+    local has_error, response_data = self:performRequest(nil, url, "GET", nil)
+    if has_error then return nil, nil end
+    if type(response_data) == "table" and response_data.attributes then
+        return response_data.attributes[attribute_name], response_data.state
+    end
+    return nil, nil
+end
+
 return API

--- a/config.lua
+++ b/config.lua
@@ -43,6 +43,25 @@ return {
             action = "media_player.media_play_pause",
             target = "media_player.living_room_sonos",
         },
+        -- Interactive Actions (with user input):
+        {
+            label = "Reading Lamp → set brightness",
+            action = "light.turn_on",
+            target = "light.reading_lamp",
+            input = {
+                type = "spin",             -- widget type (default: "spin")
+                field = "brightness_pct",  -- data key sent to Home Assistant
+                title = "Brightness",
+                min = 0,
+                max = 100,
+                step = 5,
+                hold_step = 10,
+                unit = "%",
+                default = 50,
+                fetch_current = true,       -- query current value before showing widget
+                fetch_attribute = "brightness", -- HA attribute to read (0-255 scale, auto-converted)
+            },
+        },
         -- Get Entity States:
         {
             label = "Outside Temperature",

--- a/config.lua
+++ b/config.lua
@@ -44,6 +44,7 @@ return {
             target = "media_player.living_room_sonos",
         },
         -- Interactive Actions (with user input):
+        -- Spin: numeric value with a slider (e.g., brightness)
         {
             label = "Reading Lamp → set brightness",
             action = "light.turn_on",
@@ -60,6 +61,37 @@ return {
                 default = 50,
                 fetch_current = true,       -- query current value before showing widget
                 fetch_attribute = "brightness", -- HA attribute to read (0-255 scale, auto-converted)
+            },
+        },
+        -- Choice: select from a list of predefined options (e.g., light effect)
+        {
+            label = "Reading Lamp → set effect",
+            action = "light.turn_on",
+            target = "light.reading_lamp",
+            input = {
+                type = "choice",
+                field = "effect",
+                title = "Effect",
+                values = { "None", "Candle", "Fireplace", "Party", "Rainbow" },
+                default = "None",
+                fetch_current = true,       -- pre-select the current effect
+                fetch_attribute = "effect",
+            },
+        },
+        -- Text: free-form text input (e.g., a URL or search query)
+        {
+            label = "Play Media URL",
+            action = "media_player.play_media",
+            target = "media_player.living_room_sonos",
+            data = {
+                media_content_type = "music",
+            },
+            input = {
+                type = "text",
+                field = "media_content_id",
+                title = "Media URL",
+                hint = "Enter a URL...",
+                default = "",
             },
         },
         -- Get Entity States:

--- a/main.lua
+++ b/main.lua
@@ -7,6 +7,8 @@ local Dispatcher = require("dispatcher")
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
 local SpinWidget = require("ui/widget/spinwidget")
+local InputDialog = require("ui/widget/inputdialog")
+local RadioButtonWidget = require("ui/widget/radiobuttonwidget")
 local API = require("api")
 
 -- Use debug_config.lua if it exists (for development); otherwise config.lua (for end-user)
@@ -73,6 +75,10 @@ function HomeAssistant:showInputWidget(entity)
 
     if input_type == "spin" then
         self:showSpinInput(entity)
+    elseif input_type == "choice" then
+        self:showChoiceInput(entity)
+    elseif input_type == "text" then
+        self:showTextInput(entity)
     else
         self:buildMessage(entity, true,
             string.format("Unsupported input type: '%s'", input_type))
@@ -111,6 +117,92 @@ function HomeAssistant:showSpinInput(entity)
             self:executeAction(modified)
         end,
     })
+end
+
+--- Show a RadioButtonWidget for selecting from predefined choices
+-- Config: input = { type = "choice", field = "color_name", title = "Color",
+--                   values = { "red", "blue", "warm_white" }, default = "warm_white" }
+function HomeAssistant:showChoiceInput(entity)
+    local input = entity.input
+
+    if not input.values or #input.values == 0 then
+        self:buildMessage(entity, true, "No 'values' configured for choice input")
+        return
+    end
+
+    -- Optionally fetch the current value from Home Assistant
+    local current_value = input.default
+    if input.fetch_current and entity.target and type(entity.target) == "string" then
+        local fetched = API:getAttributeValue(entity.target, input.fetch_attribute or input.field)
+        if fetched ~= nil then
+            current_value = tostring(fetched)
+        end
+    end
+
+    -- Build radio button rows from the values list
+    local radio_buttons = {}
+    for _, val in ipairs(input.values) do
+        local str_val = tostring(val)
+        table.insert(radio_buttons, {
+            { text = str_val, provider = val, checked = (str_val == tostring(current_value)) },
+        })
+    end
+
+    UIManager:show(RadioButtonWidget:new{
+        title_text = input.title or entity.label,
+        radio_buttons = radio_buttons,
+        callback = function(radio)
+            local modified = self:buildModifiedEntity(entity, radio.provider)
+            self:executeAction(modified)
+        end,
+    })
+end
+
+--- Show an InputDialog for free-form text input
+-- Config: input = { type = "text", field = "media_content_id", title = "URL",
+--                   default = "", hint = "Enter a URL..." }
+function HomeAssistant:showTextInput(entity)
+    local input = entity.input
+
+    -- Optionally fetch the current value from Home Assistant
+    local current_value = input.default or ""
+    if input.fetch_current and entity.target and type(entity.target) == "string" then
+        local fetched = API:getAttributeValue(entity.target, input.fetch_attribute or input.field)
+        if fetched ~= nil then
+            current_value = tostring(fetched)
+        end
+    end
+
+    local input_dialog
+    input_dialog = InputDialog:new{
+        title = input.title or entity.label,
+        input = current_value,
+        input_hint = input.hint or "",
+        input_type = input.input_type, -- nil for text, "number" for numeric
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(input_dialog)
+                    end,
+                },
+                {
+                    text = _("OK"),
+                    is_enter_default = true,
+                    callback = function()
+                        local value = input_dialog:getInputText()
+                        UIManager:close(input_dialog)
+                        local modified = self:buildModifiedEntity(entity, value)
+                        self:executeAction(modified)
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(input_dialog)
+    input_dialog:onShowKeyboard()
 end
 
 --- Create a shallow copy of entity with the user-chosen value merged into data

--- a/main.lua
+++ b/main.lua
@@ -6,6 +6,7 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local Dispatcher = require("dispatcher")
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
+local SpinWidget = require("ui/widget/spinwidget")
 local API = require("api")
 
 -- Use debug_config.lua if it exists (for development); otherwise config.lua (for end-user)
@@ -35,8 +36,19 @@ function HomeAssistant:init()
 end
 
 --- Handle ActivateHAEvent (via menu or gesture)
--- Flow: determine endpoint -> call API method -> display result message to user
+-- If the entity has an 'input' field, show an interactive widget first;
+-- otherwise execute the action directly.
 function HomeAssistant:onActivateHAEvent(entity)
+    if entity.input and entity.action then
+        self:showInputWidget(entity)
+        return
+    end
+    self:executeAction(entity)
+end
+
+--- Execute the actual HA API call
+-- Flow: determine endpoint -> call API method -> display result message to user
+function HomeAssistant:executeAction(entity)
     local has_error, response_data
 
     if entity.action then
@@ -51,6 +63,90 @@ function HomeAssistant:onActivateHAEvent(entity)
     end
 
     self:buildMessage(entity, has_error, response_data)
+end
+
+--- Show an interactive input widget before executing an action
+-- Routes to the appropriate widget based on input.type.
+function HomeAssistant:showInputWidget(entity)
+    local input = entity.input
+    local input_type = input.type or "spin"
+
+    if input_type == "spin" then
+        self:showSpinInput(entity)
+    else
+        self:buildMessage(entity, true,
+            string.format("Unsupported input type: '%s'", input_type))
+    end
+end
+
+--- Show a SpinWidget for numeric input, then execute the action with the chosen value
+function HomeAssistant:showSpinInput(entity)
+    local input = entity.input
+    local initial_value = input.default or input.min or 0
+    local fetch_info = nil
+
+    -- Optionally fetch the current attribute value from Home Assistant
+    if input.fetch_current and entity.target and type(entity.target) == "string" then
+        local current, err = self:fetchCurrentAttributeValue(entity, input)
+        if current ~= nil then
+            initial_value = current
+        elseif err then
+            fetch_info = "Could not fetch current value: " .. err
+        end
+    end
+
+    UIManager:show(SpinWidget:new{
+        title_text = input.title or entity.label,
+        info_text = fetch_info,
+        value = initial_value,
+        value_min = input.min or 0,
+        value_max = input.max or 100,
+        value_step = input.step or 1,
+        value_hold_step = input.hold_step or 10,
+        unit = input.unit or "",
+        default_value = input.default,
+        ok_always_enabled = true,
+        callback = function(spin)
+            local modified = self:buildModifiedEntity(entity, spin.value)
+            self:executeAction(modified)
+        end,
+    })
+end
+
+--- Create a shallow copy of entity with the user-chosen value merged into data
+function HomeAssistant:buildModifiedEntity(entity, value)
+    local modified = {}
+    for k, v in pairs(entity) do modified[k] = v end
+    modified.data = {}
+    if entity.data then
+        for k, v in pairs(entity.data) do modified.data[k] = v end
+    end
+    modified.data[entity.input.field] = value
+    modified.input = nil -- prevent re-triggering the input widget
+    return modified
+end
+
+--- Fetch the current value of an entity attribute from Home Assistant
+-- Returns (value, nil) on success, or (nil, reason_string) on failure
+function HomeAssistant:fetchCurrentAttributeValue(entity, input)
+    local attr_name = input.fetch_attribute or input.field
+    local value, entity_state = API:getAttributeValue(entity.target, attr_name)
+    if type(value) ~= "number" then
+        -- If the entity is off, the attribute is likely unavailable;
+        -- treat it as "at minimum" (e.g., brightness 0 when light is off)
+        if entity_state == "off" then
+            return input.min or 0, nil
+        end
+        return nil, string.format("attribute '%s' is %s (%s)",
+            attr_name, tostring(value), type(value))
+    end
+
+    -- Handle brightness (0-255) → brightness_pct (0-100) conversion
+    if attr_name == "brightness" and input.field == "brightness_pct" then
+        value = math.floor(value / 255 * 100 + 0.5)
+    end
+
+    return math.max(input.min or 0, math.min(input.max or 100, value)), nil
 end
 
 --- Build user-facing message based on API response


### PR DESCRIPTION
Closes #20 

This pull request adds support for configuring interactive user controls.  This allows action entities to include an "input" field that displays an interactive widget, the value of which is sent with the data payload.  The user can also specify whether to fetch the current value by attribute name to populate as the default input value for the action.

User can define config for the following input types:
- "spin" -- displays a SpinWidget for numeric values (e.g. light brightness)
- "choice" -- displays a RadioButtonWidget with a list of the predefined values from the config (e.g. lighting effects)
- "text" -- displays a InputDialog for freeform entry (e.g. media URL to play)